### PR TITLE
Add synchronization of callbacks so tests are consistent

### DIFF
--- a/sqsworker.go
+++ b/sqsworker.go
@@ -148,13 +148,15 @@ func (w *Worker) consumer(ctx context.Context, in chan *sqs.Message) {
 	deleteInput := &sqs.DeleteMessageInput{QueueUrl: &w.QueueInURL}
 	hanlderInput := w.getHandlerParams()
 	var msgString string
+	var err error
+	var result []byte
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case msg := <-in:
-			result, err := w.exec(ctx, hanlderInput, msg)
+			result, err = w.exec(ctx, hanlderInput, msg)
 			if err == nil {
 				msgString = string(result)
 				sendInput.MessageBody = &msgString

--- a/sqsworker.go
+++ b/sqsworker.go
@@ -161,13 +161,11 @@ func (w *Worker) consumer(ctx context.Context, in chan *sqs.Message) {
 				err = w.sendMessage(sendInput)
 				if err != nil {
 					w.logError("send message failed!", err)
-					continue
 				}
 				deleteInput.ReceiptHandle = msg.ReceiptHandle
 				err = w.deleteMessage(deleteInput)
 				if err != nil {
 					w.logError("delete message failed!", err)
-					continue
 				}
 			} else {
 				w.logError("handler failed!", err)

--- a/sqsworker.go
+++ b/sqsworker.go
@@ -123,9 +123,6 @@ func (w *Worker) sendMessage(msg *sqs.SendMessageInput) error {
 }
 
 func (w *Worker) exec(ctx context.Context, hp *handlerParams, m *sqs.Message) ([]byte, error) {
-	if !hp.Timer.Stop() {
-		<-hp.Timer.C
-	}
 	hp.Timer.Reset(w.Timeout)
 
 	go func() {
@@ -137,6 +134,9 @@ func (w *Worker) exec(ctx context.Context, hp *handlerParams, m *sqs.Message) ([
 
 	select {
 	case result := <-hp.Done:
+		if !hp.Timer.Stop() {
+			<-hp.Timer.C
+		}
 		return result.Result, result.Err
 	case <-hp.Timer.C:
 		return nil, &HandlerTimeoutError{}

--- a/sqsworker_test.go
+++ b/sqsworker_test.go
@@ -21,17 +21,18 @@ type MockQueue struct {
 	Out     chan string
 	req     *request.Request
 	receive *sqs.ReceiveMessageOutput
+	Msg     string
 }
-
-var Msg string
 
 func (m *MockQueue) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
 	return nil, nil
 }
 
 func (m *MockQueue) ReceiveMessageRequest(input *sqs.ReceiveMessageInput) (*request.Request, *sqs.ReceiveMessageOutput) {
-	Msg = <-m.In
-	m.receive.Messages[0].Body = &Msg
+	m.Msg, _ = <-m.In
+
+	m.receive.Messages[0].Body = &m.Msg
+
 	return m.req, m.receive
 }
 
@@ -61,6 +62,7 @@ func GetMockeQueue() *MockQueue {
 		receive: &sqs.ReceiveMessageOutput{
 			Messages: []*sqs.Message{{Body: nil}},
 		},
+		Msg: "",
 	}
 }
 
@@ -97,6 +99,8 @@ func BenchmarkWorker(b *testing.B) {
 func TestTimeout(t *testing.T) {
 	queue := GetMockeQueue()
 
+	done := make(chan bool)
+
 	var handlerFunction = func(ctx context.Context, m *sqs.Message) ([]byte, error) {
 		time.Sleep(3 * time.Second)
 		return []byte(*m.Body), nil
@@ -106,6 +110,7 @@ func TestTimeout(t *testing.T) {
 		if _, ok := err.(*sqsworker.HandlerTimeoutError); !ok {
 			t.Error("expected worker.HandlerTimeoutError error")
 		}
+		close(done)
 	}
 
 	sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
@@ -122,7 +127,7 @@ func TestTimeout(t *testing.T) {
 
 	go func() {
 		queue.Push("hello")
-		time.Sleep(1 * time.Second)
+		<-done
 		w.Close()
 	}()
 
@@ -133,6 +138,7 @@ func TestTimeout(t *testing.T) {
 
 func TestError(t *testing.T) {
 	queue := GetMockeQueue()
+	done := make(chan bool)
 
 	var handlerFunction = func(ctx context.Context, m *sqs.Message) ([]byte, error) {
 		return []byte(*m.Body), errors.New("test error")
@@ -142,6 +148,7 @@ func TestError(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error")
 		}
+		close(done)
 	}
 
 	sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
@@ -156,7 +163,8 @@ func TestError(t *testing.T) {
 	w.Queue = queue
 
 	go func() {
-		queue.Push("hello")
+		queue.Push("hello") // No message are sent on error, so no pop needed
+		<-done
 		w.Close()
 	}()
 
@@ -167,6 +175,7 @@ func TestError(t *testing.T) {
 
 func TestProcessMessage(t *testing.T) {
 	queue := GetMockeQueue()
+	done := make(chan bool)
 
 	var handlerFunction = func(ctx context.Context, m *sqs.Message) ([]byte, error) {
 		transform := fmt.Sprint(*m.Body, " ", "world")
@@ -177,6 +186,7 @@ func TestProcessMessage(t *testing.T) {
 		if string(result) != "hello world" {
 			t.Error("Expected: ", "hello world", "Actual: ", string(result))
 		}
+		close(done)
 	}
 
 	sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
@@ -194,6 +204,7 @@ func TestProcessMessage(t *testing.T) {
 	go func() {
 		queue.Push("hello")
 		queue.Pop()
+		<-done
 		w.Close()
 	}()
 


### PR DESCRIPTION
There were race conditions in the tests between the queue.Close and worker.Close. Select will randomly select if selecting on multiple channels, so there were cases where closing the worker would result in messages not being received, and callbacks not being executed, or cases where queue.Close() happened first, resulting in empty messages on receives to the workers, failing some of the tests. 

This is a very a difficult to reproduce error, however, there was this build failure: https://circleci.com/gh/ajbeach2/sqsworker/100 that is related.

The fix is requiring that the callback is executed before closing the Worker, so cancelation happens only after a message has been fully consumed. A consequence fo this is that Callbacks are executed regardless if the handler functions error

 