### PR TITLE
remove buggy timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Concurrent SQS Consumer written on Go
 ## Documentation
 
 The Worker type represents a SQS consumer that can process sqs messages from a
-SQS queue and optionally send the results to a queue. The inenteded use is
+SQS queue and optionally send the results to a queue. The intended use is
 multiple concurrent consumers reading from the same queue which execute the
 hander function defined on the Worker struct.
 
@@ -35,8 +35,7 @@ type Handler func(context.Context, *sqs.Message) ([]byte, error)
 
 A Worker Struct can be initialized with the NewWorker method, and you may optionally
 define an outbound queue, and number of concurrent workers. If the number of workers
-is not set, the number of workers defaults to runtime.NumCPU(). A Timeout in seconds
-can be set where a handler will fail on a Timeout. The default, if this is not set, is 30 seconds.
+is not set, the number of workers defaults to runtime.NumCPU().
 
 ```go
 package main

--- a/doc.go
+++ b/doc.go
@@ -22,21 +22,19 @@
 //
 // A Worker Struct can be initialized with the NewWorker method, and you may optionally
 // define an outbound queue, and number of concurrent workers. If the number of workers
-// is not set, the number of workers defaults to runtime.NumCPU(). A Timeout in seconds
-// can be set where a handler will fail on a Timeout. The default, if this is not set, is 30 seconds.
+// is not set, the number of workers defaults to runtime.NumCPU().
 //
 //	sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
 //	w := sqsworker.NewWorker(sess, sqsworker.WorkerConfig{
 //		QueueIn:  "https://sqs.us-east-1.amazonaws.com/88888888888/In",
 //		QueueOut: "https://sqs.us-east-1.amazonaws.com/88888888888/Out",
 //		Workers:  4,
-//		Timeout,  30, // Handler Timeout in seconds.
 //		Handler:  handlerFunction,
 //		Name:     "TestApp",
 //	})
 //	w.Run()
 //
-// The worker will send messages to the QueuOut queue on succesfull runs.
+// The worker will send messages to the QueuOut queue on successful runs.
 //
 // Concurrency
 //


### PR DESCRIPTION
https://github.com/ajbeach2/sqsworker/issues/21

This removes the timer functionality. This is buggy and racy in the way it is built with reusing the same timer aspect. This will be removed until a better solution for a reusable timer is found.